### PR TITLE
colab: kill old processes before restarting

### DIFF
--- a/avatarify.ipynb
+++ b/avatarify.ipynb
@@ -301,6 +301,20 @@
     {
       "cell_type": "code",
       "metadata": {
+        "id": "4Pn9r975mRqx",
+        "colab_type": "code",
+        "colab": {}
+      },
+      "source": [
+        "# If restarting workers is giving you trouble, try killing the old processes first before restarting workers \n",
+        "# !kill -9 $(ps aux | grep 'afy/cam_fomm.py' | awk '{print $2}') 2> /dev/null"
+      ],
+      "execution_count": 0,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "metadata": {
         "id": "8PnArK75mRqx",
         "colab_type": "code",
         "colab": {}


### PR DESCRIPTION
Optional code block to help user restart workers. If restarts are giving you trouble, try killing the old processes first before restarting workers.