### PR TITLE
Fixing a reloading issue and a typo

### DIFF
--- a/afy/cam_fomm.py
+++ b/afy/cam_fomm.py
@@ -24,7 +24,7 @@ if _platform == 'darwin':
         exit()
 
 
-def is_new_frame_better(source, driving, precitor):
+def is_new_frame_better(source, driving, predictor):
     global avatar_kp
     global display_string
     

--- a/afy/cam_fomm.py
+++ b/afy/cam_fomm.py
@@ -376,7 +376,7 @@ if __name__ == "__main__":
             elif key == ord('l'):
                 try:
                     log('Reloading avatars...')
-                    avatars = load_images()
+                    avatars, avatar_names = load_images()
                     passthrough = False
                     log("Images reloaded")
                 except:


### PR DESCRIPTION
After reloading the avatars you were not able to navigate anymore. This was due a wrong call of load_images()

In the definition of is_new_frame_better was a typo, that did not produce errors because the global variable with the same name was used.