### PR TITLE
Fix opencv versions for compatibility

### DIFF
--- a/requirements_client.txt
+++ b/requirements_client.txt
@@ -3,4 +3,4 @@ PyYAML==5.1
 requests==2.23
 msgpack-numpy==0.4.5
 pyzmq==19.0.0
-opencv-python==3.4.9.33
+opencv-python==3.4.5.20


### PR DESCRIPTION
The latest opencv version cause compatibility issue for MacOS Sierra (10.12 or less)
By changing the open-cv requirement for Mac to this version, all MacOS versions are compatible.