### PR TITLE
Fix using current avatar for overlay

### DIFF
--- a/afy/cam_fomm.py
+++ b/afy/cam_fomm.py
@@ -393,7 +393,7 @@ if __name__ == "__main__":
                 log(key)
 
             if overlay_alpha > 0:
-                preview_frame = cv2.addWeighted( avatars[cur_ava], overlay_alpha, frame, 1.0 - overlay_alpha, 0.0)
+                preview_frame = cv2.addWeighted( avatar, overlay_alpha, frame, 1.0 - overlay_alpha, 0.0)
             else:
                 preview_frame = frame.copy()
             


### PR DESCRIPTION
It would always use the last avatar loaded from disk, even if the
current avatar was downloaded StyleGAN