### PR TITLE
Fix crash if zooming out near frame edge

### DIFF
--- a/afy/cam_fomm.py
+++ b/afy/cam_fomm.py
@@ -272,8 +272,8 @@ if __name__ == "__main__":
             frame = frame[..., ::-1]
             frame_orig = frame.copy()
 
-            frame, lrudwh = crop(frame, p=frame_proportion, offset_x=frame_offset_x, offset_y=frame_offset_y)
-            frame_lrudwh = lrudwh
+            frame, (frame_offset_x, frame_offset_y) = crop(frame, p=frame_proportion, offset_x=frame_offset_x, offset_y=frame_offset_y)
+
             frame = resize(frame, (IMG_SIZE, IMG_SIZE))[..., :3]
 
             if find_keyframe:
@@ -320,29 +320,21 @@ if __name__ == "__main__":
                 frame_proportion += 0.05
                 frame_proportion = min(frame_proportion, 1.0)
             elif key == ord('H'):
-                if frame_lrudwh[0] - 1 > 0:
-                    frame_offset_x -= 1
+                frame_offset_x -= 1
             elif key == ord('h'):
-                if frame_lrudwh[0] - 5 > 0:
-                    frame_offset_x -= 5
+                frame_offset_x -= 5
             elif key == ord('K'):
-                if frame_lrudwh[1] + 1 < frame_lrudwh[4]:
-                    frame_offset_x += 1
+                frame_offset_x += 1
             elif key == ord('k'):
-                if frame_lrudwh[1] + 5 < frame_lrudwh[4]:
-                    frame_offset_x += 5
+                frame_offset_x += 5
             elif key == ord('J'):
-                if frame_lrudwh[2] - 1 > 0:
-                    frame_offset_y -= 1
+                frame_offset_y -= 1
             elif key == ord('j'):
-                if frame_lrudwh[2] - 5 > 0:
-                    frame_offset_y -= 5
+                frame_offset_y -= 5
             elif key == ord('U'):
-                if frame_lrudwh[3] + 1 < frame_lrudwh[5]:
-                    frame_offset_y += 1
+                frame_offset_y += 1
             elif key == ord('u'):
-                if frame_lrudwh[3] + 5 < frame_lrudwh[5]:
-                    frame_offset_y += 5
+                frame_offset_y += 5
             elif key == ord('Z'):
                 frame_offset_x = 0
                 frame_offset_y = 0

--- a/afy/utils.py
+++ b/afy/utils.py
@@ -114,6 +114,10 @@ class AccumDict:
         return self.__str__()
 
 
+def clamp(value, min_value, max_value):
+    return max(min(value, max_value), min_value)
+
+
 def crop(img, p=0.7, offset_x=0, offset_y=0):
     h, w = img.shape[:2]
     x = int(min(w, h) * p)
@@ -121,12 +125,16 @@ def crop(img, p=0.7, offset_x=0, offset_y=0):
     r = w - l
     u = (h - x) // 2
     d = h - u
+
+    offset_x = clamp(offset_x, -l, w - r)
+    offset_y = clamp(offset_y, -u, h - d)
+
     l += offset_x
     r += offset_x
     u += offset_y
     d += offset_y
 
-    return img[u:d, l:r], (l,r,u,d,w,h)
+    return img[u:d, l:r], (offset_x, offset_y)
 
 
 def pad_img(img, target_size, default_pad=0):


### PR DESCRIPTION
Added clamping of offsets so that lrud always lies within image
boundaries. The adjusted offsets are returned to main so that it is no
longer necessary to test if an offset increase/decrease should be
allowed.