### PR TITLE
Fixes for running with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN  update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1 \
 
 ARG PYTORCH_WHEEL="https://download.pytorch.org/whl/cu100/torch-1.0.0-cp37-cp37m-linux_x86_64.whl"
 ARG FACE_ALIGNMENT_GIT="git+https://github.com/1adrianb/face-alignment"
-ARG AVATARIFY_COMMIT="182bf4a10aba279cb837d6c8e6c281191114fd77"
+ARG AVATARIFY_COMMIT="a300fcaadb6a6964e69d4a90db9e7d72bb87e791"
 ARG FOMM_COMMIT="efbe0a6f17b38360ff9a446fddfbb3ce5493534c"
 
 RUN git clone https://github.com/alievk/avatarify.git /app/avatarify && cd /app/avatarify && git checkout ${AVATARIFY_COMMIT} \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
 FROM nvcr.io/nvidia/cuda:10.0-cudnn7-runtime-ubuntu18.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update \
- && DEBIAN_FRONTEND=noninteractive apt-get -qqy install curl python3-pip python3-tk ffmpeg git less nano libsm6 libxext6 libxrender-dev \
+ && DEBIAN_FRONTEND=noninteractive apt-get -qqy install curl python3-pip python3-tk python3.7-dev ffmpeg git less nano libsm6 libxext6 libxrender-dev \
  && rm -rf /var/lib/apt/lists/*
 
-ARG PYTORCH_WHEEL="https://download.pytorch.org/whl/cu100/torch-1.0.0-cp36-cp36m-linux_x86_64.whl"
+# use python3.7 by default
+RUN  update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1 \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2 \
+    && update-alternatives  --set python /usr/bin/python3.7 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 1 \
+    && update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 2 \
+    && update-alternatives  --set python3 /usr/bin/python3.7 \
+    && python -m pip install --upgrade setuptools pip wheel
+
+ARG PYTORCH_WHEEL="https://download.pytorch.org/whl/cu100/torch-1.0.0-cp37-cp37m-linux_x86_64.whl"
 ARG FACE_ALIGNMENT_GIT="git+https://github.com/1adrianb/face-alignment"
 ARG AVATARIFY_COMMIT="182bf4a10aba279cb837d6c8e6c281191114fd77"
 ARG FOMM_COMMIT="efbe0a6f17b38360ff9a446fddfbb3ce5493534c"
@@ -16,8 +25,8 @@ WORKDIR /app/avatarify
 
 RUN bash scripts/download_data.sh
 
-RUN pip3 install ${PYTORCH_WHEEL} ${FACE_ALIGNMENT_GIT} -r requirements.txt \
- && pip3 install ${PYTORCH_WHEEL} ${FACE_ALIGNMENT_GIT} -r fomm/requirements.txt \
+RUN pip3 install ${PYTORCH_WHEEL} -r requirements.txt \
+ && pip3 install ${PYTORCH_WHEEL} -r fomm/requirements.txt \
  && rm -rf /root/.cache/pip
 
 ENV PYTHONPATH="/app/avatarify:/app/avatarify/fomm"

--- a/run.sh
+++ b/run.sh
@@ -134,7 +134,7 @@ else
                 --relative \
                 --adapt_scale \
                 $@ \
-        && $(DOCKER_DEPRECATION_WARNING)
+        && $DOCKER_DEPRECATION_WARNING
         xhost -local:root
 
     else
@@ -148,7 +148,7 @@ else
                 --relative \
                 --adapt_scale \
                 $@ \
-        && $(DOCKER_DEPRECATION_WARNING)
+        && $DOCKER_DEPRECATION_WARNING
     fi
 
 fi

--- a/run.sh
+++ b/run.sh
@@ -97,7 +97,6 @@ if [[ $USE_DOCKER == 0 ]]; then
 else
 
     source scripts/settings.sh
-    DOCKER_DEPRECATION_WARNING=:
 
     if [[ $ENABLE_VCAM == 1 ]]; then
         bash scripts/create_virtual_camera.sh
@@ -106,7 +105,7 @@ else
     if [[ $DOCKER_NO_GPU == 0 ]]; then
         if nvidia-container-runtime -v &> /dev/null; then
             DOCKER_ARGS="$DOCKER_ARGS --runtime=nvidia"
-            DOCKER_DEPRECATION_WARNING= echo "Warning : Outdated Docker gpu support, please update !"
+            echo "Warning : Outdated Docker gpu support, please update !"
         else
             DOCKER_ARGS="$DOCKER_ARGS --gpus all"
         fi
@@ -133,8 +132,7 @@ else
                 --virt-cam $CAMID_VIRT \
                 --relative \
                 --adapt_scale \
-                $@ \
-        && $DOCKER_DEPRECATION_WARNING
+                $@
         xhost -local:root
 
     else
@@ -147,8 +145,7 @@ else
                 --virt-cam $CAMID_VIRT \
                 --relative \
                 --adapt_scale \
-                $@ \
-        && $DOCKER_DEPRECATION_WARNING
+                $@
     fi
 
 fi

--- a/run.sh
+++ b/run.sh
@@ -97,13 +97,19 @@ if [[ $USE_DOCKER == 0 ]]; then
 else
 
     source scripts/settings.sh
-    
+    DOCKER_DEPRECATION_WARNING=:
+
     if [[ $ENABLE_VCAM == 1 ]]; then
         bash scripts/create_virtual_camera.sh
     fi
     
     if [[ $DOCKER_NO_GPU == 0 ]]; then
-        DOCKER_ARGS="$DOCKER_ARGS --gpus all"
+        if nvidia-container-runtime -v &> /dev/null; then
+            DOCKER_ARGS="$DOCKER_ARGS --runtime=nvidia"
+            DOCKER_DEPRECATION_WARNING= echo "Warning : Outdated Docker gpu support, please update !"
+        else
+            DOCKER_ARGS="$DOCKER_ARGS --gpus all"
+        fi
     fi
 
     if [[ $DOCKER_IS_LOCAL_CLIENT == 1 ]]; then
@@ -112,9 +118,7 @@ else
         DOCKER_ARGS="$DOCKER_ARGS -p 5557:5554 -p 5557:5558"
     fi
 
-    
 
-    
     if [[ $IS_WORKER == 0 ]]; then
         xhost +local:root
         docker run $DOCKER_ARGS -it --rm --privileged  \
@@ -129,7 +133,8 @@ else
                 --virt-cam $CAMID_VIRT \
                 --relative \
                 --adapt_scale \
-                $@
+                $@ \
+        && $(DOCKER_DEPRECATION_WARNING)
         xhost -local:root
 
     else
@@ -142,8 +147,8 @@ else
                 --virt-cam $CAMID_VIRT \
                 --relative \
                 --adapt_scale \
-                $@
+                $@ \
+        && $(DOCKER_DEPRECATION_WARNING)
     fi
-    
 
 fi


### PR DESCRIPTION
- Fixed Dockerfile for python 3.7 compatibility : numba required python=3.7, but the torch wheel was in 3.6
- Remove double requirement for face_alignment in Dockerfile which created version conflict
- add support older versions Docker gpu in run.sh

I could only test these fixes:
- by running the server as remote
- having an old Docker version which requires option "--runtime=nvidia" instead of "--gpus=all"
so if you have a way to test these cases it would be best before merging.

NB: there is a slight mistake in the wiki for remote usage, the command written there is `docker build -t avatarify` instead of `docker build -t avatarify .` 