### PR TITLE
Add s3fd_convert.pth & 2DFAN-4.pth to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip3 --no-cache-dir install ${PYTORCH_WHEEL} -r requirements.txt \
  && rm -rf /root/.cache/pip
 
 RUN mkdir -p /root/.face_alignment/data \
- && curl -s https://www.adrianbulat.com/downloads/python-fan/s3fd_convert.pth /root/.face_alignment/data/s3fd_convert.pth
+ && curl -s https://www.adrianbulat.com/downloads/python-fan/s3fd_convert.pth -o /root/.face_alignment/data/s3fd_convert.pth
 
 ENV PYTHONPATH="/app/avatarify:/app/avatarify/fomm"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN pip3 --no-cache-dir install ${PYTORCH_WHEEL} -r requirements.txt \
  && rm -rf /root/.cache/pip
 
 RUN mkdir -p /root/.face_alignment/data \
- && curl https://www.adrianbulat.com/downloads/python-fan/s3fd_convert.pth /root/.face_alignment/data/s3fd_convert.pth
+ && curl -s https://www.adrianbulat.com/downloads/python-fan/s3fd_convert.pth /root/.face_alignment/data/s3fd_convert.pth
 
 ENV PYTHONPATH="/app/avatarify:/app/avatarify/fomm"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,9 @@ RUN pip3 --no-cache-dir install ${PYTORCH_WHEEL} -r requirements.txt \
  && pip3 --no-cache-dir install ${PYTORCH_WHEEL} -r fomm/requirements.txt \
  && rm -rf /root/.cache/pip
 
+RUN mkdir -p /root/.face_alignment/data \
+ && curl https://www.adrianbulat.com/downloads/python-fan/s3fd_convert.pth /root/.face_alignment/data/s3fd_convert.pth
+
 ENV PYTHONPATH="/app/avatarify:/app/avatarify/fomm"
 
 EXPOSE 5557

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,8 @@ WORKDIR /app/avatarify
 
 RUN bash scripts/download_data.sh
 
-RUN pip3 install ${PYTORCH_WHEEL} -r requirements.txt \
- && pip3 install ${PYTORCH_WHEEL} -r fomm/requirements.txt \
+RUN pip3 --no-cache-dir install ${PYTORCH_WHEEL} -r requirements.txt \
+ && pip3 --no-cache-dir install ${PYTORCH_WHEEL} -r fomm/requirements.txt \
  && rm -rf /root/.cache/pip
 
 ENV PYTHONPATH="/app/avatarify:/app/avatarify/fomm"

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN pip3 --no-cache-dir install ${PYTORCH_WHEEL} -r requirements.txt \
  && rm -rf /root/.cache/pip
 
 RUN mkdir -p /root/.face_alignment/data \
- && curl -s https://www.adrianbulat.com/downloads/python-fan/s3fd_convert.pth -o /root/.face_alignment/data/s3fd_convert.pth
+ && curl -s https://www.adrianbulat.com/downloads/python-fan/s3fd_convert.pth -o /root/.face_alignment/data/s3fd_convert.pth \
+ && curl -s https://www.adrianbulat.com/downloads/python-fan/2DFAN-4.pth.tar -o /root/.face_alignment/data/2DFAN-4.pth.tar
 
 ENV PYTHONPATH="/app/avatarify:/app/avatarify/fomm"
 


### PR DESCRIPTION
1. Add `--no-cache-dir` flag to avoid `memory error` while building in dockerhub;
2. Add face-alignment model file `s3fd_convert.pth` and  `2DFAN-4.pth`, making Avatarify image ready-to-use once pulled or built;
3. This Dockerfile can be built from dockerhub(see https://hub.docker.com/r/denton35/avatarify) and tested on linux GPU machine.