### PR TITLE
Update install_windows.bat

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -21,6 +21,7 @@ source $(conda info --base)/etc/profile.d/conda.sh
 conda create -y -n $CONDA_ENV_NAME python=3.7
 conda activate $CONDA_ENV_NAME
 
+conda install -y conda-libmamba-solver pip==21.0.1
 conda install -y numpy==1.19.0 scikit-image python-blosc==1.7.0 -c conda-forge
 conda install -y pytorch==1.7.1 torchvision cudatoolkit=11.0 -c pytorch
 
@@ -28,4 +29,4 @@ conda install -y pytorch==1.7.1 torchvision cudatoolkit=11.0 -c pytorch
 rm -rf fomm 2> /dev/null
 git clone https://github.com/alievk/first-order-model.git fomm
 
-pip install -r requirements.txt
+conda run pip install -r requirements.txt

--- a/scripts/install_mac.sh
+++ b/scripts/install_mac.sh
@@ -17,4 +17,6 @@ conda activate $CONDA_ENV_NAME
 #conda install -y pytorch==1.0.0 torchvision==0.2.1 -c pytorch
 #conda install -y python-blosc==1.7.0 -c conda-forge
 #conda install -y matplotlib==2.2.2
-pip install -r requirements_client.txt
+conda install -y conda-libmamba-solver pip==21.0.1
+
+conda run pip install -r requirements_client.txt

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -9,7 +9,7 @@ call scripts/settings_windows.bat
 call conda create -y -n %CONDA_ENV_NAME% python=3.7
 call conda activate %CONDA_ENV_NAME%
 
-call conda install -n base conda-libmamba-solver pip==21.0
+call conda install -n base conda-libmamba-solver pip==21.0.1
 call conda install -y numpy==1.19.0 scikit-image python-blosc==1.7.0 -c conda-forge
 call conda install -y pytorch==1.7.1 torchvision cudatoolkit=11.0 -c pytorch
 call conda install -y -c anaconda git

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -9,7 +9,7 @@ call scripts/settings_windows.bat
 call conda create -y -n %CONDA_ENV_NAME% python=3.7
 call conda activate %CONDA_ENV_NAME%
 
-call conda install -n base conda-libmamba-solver
+call conda install -n base conda-libmamba-solver pip==21.0
 call conda install -y numpy==1.19.0 scikit-image python-blosc==1.7.0 -c conda-forge
 call conda install -y pytorch==1.7.1 torchvision cudatoolkit=11.0 -c pytorch
 call conda install -y -c anaconda git

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -17,4 +17,4 @@ REM ###FOMM###
 call rmdir fomm /s /q
 call git clone https://github.com/alievk/first-order-model.git fomm
 
-call pip install -r requirements.txt --use-feature=2020-resolver
+call python3 -m pip install -r requirements.txt --use-feature=2020-resolver

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -9,6 +9,7 @@ call scripts/settings_windows.bat
 call conda create -y -n %CONDA_ENV_NAME% python=3.7
 call conda activate %CONDA_ENV_NAME%
 
+call conda install -n base conda-libmamba-solver
 call conda install -y numpy==1.19.0 scikit-image python-blosc==1.7.0 -c conda-forge
 call conda install -y pytorch==1.7.1 torchvision cudatoolkit=11.0 -c pytorch
 call conda install -y -c anaconda git

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -18,4 +18,4 @@ REM ###FOMM###
 call rmdir fomm /s /q
 call git clone https://github.com/alievk/first-order-model.git fomm
 
-call conda run pip install -r requirements.txt --use-feature=2020-resolver
+call conda run pip install -r requirements.txt 

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -18,4 +18,4 @@ REM ###FOMM###
 call rmdir fomm /s /q
 call git clone https://github.com/alievk/first-order-model.git fomm
 
-call python3 -m pip install -r requirements.txt --use-feature=2020-resolver
+call conda run pip install -r requirements.txt --use-feature=2020-resolver

--- a/scripts/install_windows.bat
+++ b/scripts/install_windows.bat
@@ -9,7 +9,7 @@ call scripts/settings_windows.bat
 call conda create -y -n %CONDA_ENV_NAME% python=3.7
 call conda activate %CONDA_ENV_NAME%
 
-call conda install -n base conda-libmamba-solver pip==21.0.1
+call conda install -y conda-libmamba-solver pip==21.0.1
 call conda install -y numpy==1.19.0 scikit-image python-blosc==1.7.0 -c conda-forge
 call conda install -y pytorch==1.7.1 torchvision cudatoolkit=11.0 -c pytorch
 call conda install -y -c anaconda git


### PR DESCRIPTION
Ensure pip3 is used to avoid python3/python2 collisions 

Found by running on windows with both pip and pip3 installed, with `pip` pointing to a python2 install env. This will ensure the correct version of pip is used on the system. Windows often will have multiple pip locations as depending on how you download python.